### PR TITLE
Allow for structs not bound to instances to listen to events

### DIFF
--- a/src/event-horizon/scripts/event_horizon/event_horizon.gml
+++ b/src/event-horizon/scripts/event_horizon/event_horizon.gml
@@ -75,7 +75,7 @@ function event_add_listener(eventName, eventMethod) {
 	var listenerId = _event_get_id();
 
 	var listenerData = {
-		instance: id,
+		instance: self,
 		eventMethod: eventMethod,
 		active: true,
 		listenerId: listenerId,


### PR DESCRIPTION
Just replacing id with self so you're passing on scope instead of an instance id.

In Vividerie I define all my items as structs in a global array, and then iterate over those structs and execute their processing functions. With this tiny change, it allows me to use event-horizon events inside those structs - They are not bound to any instance in the game.

Cheers